### PR TITLE
Optional visualize in table services

### DIFF
--- a/public/js/dashboard/dashboard-driver.js
+++ b/public/js/dashboard/dashboard-driver.js
@@ -677,7 +677,6 @@ const dashboardDriver = (function() {
     launch,
     isLaunched,
     getContext,
-    setActivePage,
     getTableFromDashboardPage,
     getAllTablesFromDashboardPage,
     updateDashboardInfo,

--- a/public/js/dashboard/dashboard-driver.js
+++ b/public/js/dashboard/dashboard-driver.js
@@ -5,6 +5,7 @@ import { addDashboardPageToPages } from './dashboard-utils/dashboard-pages-utils
 import { updateNavPageButtons } from './dashboard-utils/dashboard-page-buttons-utils.js';
 import setActivePage from './dashboard-utils/set-active-page.js';
 import { visualizeWhileAppending, visualizeThenRemove } from './dashboard-utils/visualize.js';
+import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js';
 import watch from '../utils/watch.js';
 import { getUserTables } from '../services/index.js';
 
@@ -125,8 +126,10 @@ const dashboardDriver = (function() {
         }
       })();
 
+      const duration = getDefaultTimeoutDuration();
+
       // remove dboItem from dashboardInfo, and table from mainTableBlock
-      visualizeThenRemove(dashboardInfo, dashboardItem, deletedTable.hyphenId, 3000);
+      visualizeThenRemove(dashboardInfo, dashboardItem, deletedTable.hyphenId, duration);
 
       // if table of current page removed, then dashboardInfo lacks one dboItem to match maxTablesInDashboardPage criterion
       // if so and there's next page, fill the gap by taking dboItem from that page of dashboardPages
@@ -147,7 +150,7 @@ const dashboardDriver = (function() {
             }
           }, 100);
         }
-      }, 3500);
+      }, duration + 500);
 
     } else if (updatedTable) {
       const tableAddress = getAddressOfFetchedEarlierTable(updatedTable.hyphenId);

--- a/public/js/dashboard/dashboard-utils/visualize.js
+++ b/public/js/dashboard/dashboard-utils/visualize.js
@@ -1,4 +1,5 @@
 import { shownTables } from '../../table/state-collectors/index.js';
+import getDefaultTimeoutDuration from '../../utils/get-default-timeout-duration.js';
 
 /**
  * Show/hide spinner, then append element.
@@ -28,7 +29,7 @@ function visualizeWhileAppending(parentNode, childNode, duration) {
  * @param {number} duration
  */
 function visualizeThenRemove(parentNode, childNode, hyphenId, duration) {
-  const time = typeof duration === 'number' && duration || 3000;
+  const time = typeof duration === 'number' && duration || getDefaultTimeoutDuration();
 
   setTimeout(() => {
     parentNode.classList.add('spinner');

--- a/public/js/services/delete-table.js
+++ b/public/js/services/delete-table.js
@@ -1,5 +1,6 @@
 import setWaitingState from '../utils/set-waiting-state.js';
 import notify from '../table/table-utils/notify.js';
+import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js';
 
 /**
  * Delete table in database.
@@ -15,19 +16,21 @@ async function deleteTable(btn, tableData) {
     method: 'DELETE',
   });
 
+  const duration = getDefaultTimeoutDuration();
+
   if (response.status === 200) {
     setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Table successfully deleted.', 'success', 3000);
+    notify(tableData.tableId, 'Table successfully deleted.', 'success', duration);
     return { deleted: true };
 
   } else if (response.status === 404) {
     setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Table not found.', 'error', 3000);
+    notify(tableData.tableId, 'Table not found.', 'error', duration);
     return { deleted: false };
 
   } else {
     setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Failed to delete. Something went wrong.', 'error', 3000);
+    notify(tableData.tableId, 'Failed to delete. Something went wrong.', 'error', duration);
     return { deleted: false };
   }
 }

--- a/public/js/services/delete-table.js
+++ b/public/js/services/delete-table.js
@@ -1,3 +1,4 @@
+import validatePositiveNumber from '../utils/validate-positive-number.js';
 import setWaitingState from '../utils/set-waiting-state.js';
 import notify from '../table/table-utils/notify.js';
 import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js';
@@ -6,32 +7,37 @@ import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js'
  * Delete table in database.
  * @param {HTMLButtonElement} btn
  * @param {object} tableData
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
  */
-async function deleteTable(btn, tableData) {
+async function deleteTable(btn, tableData, showResultDuration) {
   if (!tableData) return { deleted: false };
-
-  setWaitingState(true, tableData);
 
   const response = await fetch(`/tables/${tableData.hyphenId}`, {
     method: 'DELETE',
   });
 
-  const duration = getDefaultTimeoutDuration();
-
-  if (response.status === 200) {
-    setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Table successfully deleted.', 'success', duration);
-    return { deleted: true };
-
-  } else if (response.status === 404) {
-    setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Table not found.', 'error', duration);
-    return { deleted: false };
+  if (showResultDuration === false) {
+    return response;
 
   } else {
-    setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Failed to delete. Something went wrong.', 'error', duration);
-    return { deleted: false };
+    const duration = validatePositiveNumber(showResultDuration) || getDefaultTimeoutDuration();
+    setWaitingState(true, tableData);
+
+    if (response.status === 200) {
+      setWaitingState(false, tableData);
+      notify(tableData.tableId, 'Table successfully deleted.', 'success', duration);
+      return { deleted: true };
+
+    } else if (response.status === 404) {
+      setWaitingState(false, tableData);
+      notify(tableData.tableId, 'Table not found.', 'error', duration);
+      return { deleted: false };
+
+    } else {
+      setWaitingState(false, tableData);
+      notify(tableData.tableId, 'Failed to delete. Something went wrong.', 'error', duration);
+      return { deleted: false };
+    }
   }
 }
 

--- a/public/js/services/delete-table.js
+++ b/public/js/services/delete-table.js
@@ -7,7 +7,7 @@ import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js'
  * Delete table in database.
  * @param {HTMLButtonElement} btn
  * @param {object} tableData
- * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response is returned)
  */
 async function deleteTable(btn, tableData, showResultDuration) {
   if (!tableData) return { deleted: false };

--- a/public/js/services/get-table.js
+++ b/public/js/services/get-table.js
@@ -6,7 +6,7 @@ import notify from '../table/table-utils/notify.js';
  * Get table.
  * @param {HTMLButtonElement} btn
  * @param {string} id
- * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response is returned)
  */
 async function getTable(btn, { id } = {}, showResultDuration) {
   if (!id) return null;

--- a/public/js/services/get-table.js
+++ b/public/js/services/get-table.js
@@ -1,3 +1,4 @@
+import validatePositiveNumber from '../utils/validate-positive-number.js';
 import setWaitingState from '../utils/set-waiting-state.js';
 import notify from '../table/table-utils/notify.js';
 
@@ -5,23 +6,31 @@ import notify from '../table/table-utils/notify.js';
  * Get table.
  * @param {HTMLButtonElement} btn
  * @param {string} id
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
  */
-async function getTable(btn, { id } = {}) {
+async function getTable(btn, { id } = {}, showResultDuration) {
   if (!id) return null;
-  setWaitingState(true, { id: 'dashboardBlock' });
 
   const response = await fetch(`/tables/${id}`, {
     method: 'GET',
   });
 
-  if (response.status === 200 || response.status === 304) {
-    setWaitingState(false, { id: 'dashboardBlock' });
-    return response.json();
+  if (showResultDuration === false) {
+    return response;
 
   } else {
-    setWaitingState(false, { id: 'dashboardBlock' });
-    notify('dashboardInfo', 'Table not found. Make sure you search own table, not another user\'s one.', 'error', 5000);
-    return null;
+    const duration = validatePositiveNumber(showResultDuration) || 5000;
+    setWaitingState(true, { id: 'dashboardBlock' });
+
+    if (response.status === 200 || response.status === 304) {
+      setWaitingState(false, { id: 'dashboardBlock' });
+      return response.json();
+
+    } else {
+      setWaitingState(false, { id: 'dashboardBlock' });
+      notify('dashboardInfo', 'Table not found. Make sure you search own table, not another user\'s one.', 'error', duration);
+      return null;
+    }
   }
 }
 

--- a/public/js/services/get-user-tables.js
+++ b/public/js/services/get-user-tables.js
@@ -8,7 +8,7 @@ import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js'
  * Get all tables of logged in user.
  * @param {HTMLButtonElement} btn
  * @param {object} options - e.g. { limit: 10, skip: 20 }
- * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response is returned)
  */
 async function getUserTables(btn, options, showResultDuration) {
   const queryStrings = makeQueryStrings(options, ['limit', 'skip'], 'number');

--- a/public/js/services/get-user-tables.js
+++ b/public/js/services/get-user-tables.js
@@ -1,3 +1,4 @@
+import validatePositiveNumber from '../utils/validate-positive-number.js';
 import setWaitingState from '../utils/set-waiting-state.js';
 import makeQueryStrings from '../utils/make-query-strings.js';
 import notify from '../table/table-utils/notify.js';
@@ -7,24 +8,31 @@ import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js'
  * Get all tables of logged in user.
  * @param {HTMLButtonElement} btn
  * @param {object} options - e.g. { limit: 10, skip: 20 }
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
  */
-async function getUserTables(btn, options) {
-  setWaitingState(true, { id: 'dashboardBlock' });
-
+async function getUserTables(btn, options, showResultDuration) {
   const queryStrings = makeQueryStrings(options, ['limit', 'skip'], 'number');
   const baseUrl = `${baseURI}tables`;
   const url = queryStrings ? `${baseUrl}?${queryStrings}` : baseUrl;
 
   const response = await fetch(url, { method: 'GET' });
 
-  if (response.status === 200 || response.status === 304) {
-    setWaitingState(false, { id: 'dashboardBlock' });
-    return response.json();
+  if (showResultDuration === false) {
+    return response;
 
   } else {
-    setWaitingState(false, { id: 'dashboardBlock' });
-    notify('dashboardInfo', 'Something went wrong.', 'error', getDefaultTimeoutDuration());
-    return [];
+    const duration = validatePositiveNumber(showResultDuration) || getDefaultTimeoutDuration();
+    setWaitingState(true, { id: 'dashboardBlock' });
+
+    if (response.status === 200 || response.status === 304) {
+      setWaitingState(false, {id: 'dashboardBlock'});
+      return response.json();
+
+    } else {
+      setWaitingState(false, {id: 'dashboardBlock'});
+      notify('dashboardInfo', 'Something went wrong.', 'error', duration);
+      return [];
+    }
   }
 }
 

--- a/public/js/services/get-user-tables.js
+++ b/public/js/services/get-user-tables.js
@@ -1,6 +1,7 @@
 import setWaitingState from '../utils/set-waiting-state.js';
 import makeQueryStrings from '../utils/make-query-strings.js';
 import notify from '../table/table-utils/notify.js';
+import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js';
 
 /**
  * Get all tables of logged in user.
@@ -22,7 +23,7 @@ async function getUserTables(btn, options) {
 
   } else {
     setWaitingState(false, { id: 'dashboardBlock' });
-    notify('dashboardInfo', 'Something went wrong.', 'error', 3000);
+    notify('dashboardInfo', 'Something went wrong.', 'error', getDefaultTimeoutDuration());
     return [];
   }
 }

--- a/public/js/services/save-new-table.js
+++ b/public/js/services/save-new-table.js
@@ -8,7 +8,7 @@ import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js'
  * Save new table to server.
  * @param {HTMLButtonElement} btn
  * @param {object} tableData
- * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response is returned)
  */
 async function saveNewTable(btn, tableData, showResultDuration) {
   // exclude tableId and convert data to JSON

--- a/public/js/services/save-new-table.js
+++ b/public/js/services/save-new-table.js
@@ -1,6 +1,7 @@
 import getUserTablesHyphenIds from './get-user-tables-hyphen-ids.js';
 import setWaitingState from '../utils/set-waiting-state.js';
 import notify from '../table/table-utils/notify.js';
+import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js';
 
 /**
  * Save new table to server.
@@ -27,20 +28,22 @@ async function saveNewTable(btn, tableData) {
     body: tableDataJSON,
   });
 
+  const duration = getDefaultTimeoutDuration();
+
   if (response.status === 200) {
     setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Table successfully saved.', 'success', 3000);
+    notify(tableData.tableId, 'Table successfully saved.', 'success', duration);
     return true;
   }
 
   if (response.status === 400) {
     setWaitingState(false, tableData);
-    notify(tableData.tableId, 'One or more fields of table are not valid.', 'error', 3000);
+    notify(tableData.tableId, 'One or more fields of table are not valid.', 'error', duration);
   }
 
   if (response.status === 401) {
     setWaitingState(false, tableData);
-    notify(tableData.tableId, 'Table not saved. Please authorize.', 'error', 3000);
+    notify(tableData.tableId, 'Table not saved. Please authorize.', 'error', duration);
   }
 
   if (response.status === 409) {

--- a/public/js/services/update-table.js
+++ b/public/js/services/update-table.js
@@ -1,5 +1,6 @@
 import setWaitingState from '../utils/set-waiting-state.js';
 import notify from '../table/table-utils/notify.js';
+import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js';
 
 /**
  * Update existing table.
@@ -26,7 +27,7 @@ async function updateTable(btn, tableData) {
     body: tableDataJSON,
   });
 
-  const _notify = (info, success) => { notify(tableData.tableId, info, success || 'error', 3000); };
+  const _notify = (info, success) => { notify(tableData.tableId, info, success || 'error', getDefaultTimeoutDuration()); };
 
   const result = await response.json();
   setWaitingState(false, tableData);

--- a/public/js/services/update-table.js
+++ b/public/js/services/update-table.js
@@ -1,3 +1,4 @@
+import validatePositiveNumber from '../utils/validate-positive-number.js';
 import setWaitingState from '../utils/set-waiting-state.js';
 import notify from '../table/table-utils/notify.js';
 import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js';
@@ -6,8 +7,9 @@ import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js'
  * Update existing table.
  * @param {HTMLButtonElement} btn
  * @param {object} tableData
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
  */
-async function updateTable(btn, tableData) {
+async function updateTable(btn, tableData, showResultDuration) {
   // exclude tableId and convert data to JSON
   const tableDataJSON = (() => {
     const tData = {};
@@ -17,8 +19,6 @@ async function updateTable(btn, tableData) {
     return JSON.stringify(tData);
   })();
 
-  setWaitingState(true, tableData);
-
   const response = await fetch('/tables', {
     method: 'PATCH',
     headers: {
@@ -27,20 +27,27 @@ async function updateTable(btn, tableData) {
     body: tableDataJSON,
   });
 
-  const _notify = (info, success) => { notify(tableData.tableId, info, success || 'error', getDefaultTimeoutDuration()); };
+  if (showResultDuration === false) {
+    return response;
 
-  const result = await response.json();
-  setWaitingState(false, tableData);
+  } else {
+    const duration = validatePositiveNumber(showResultDuration) || getDefaultTimeoutDuration();
+    const _notify = (info, success) => { notify(tableData.tableId, info, success || 'error', duration); };
+    setWaitingState(true, tableData);
 
-  if (response.status === 200) {
-    _notify(result.updated ? 'Table successfully updated.' : 'Empty table deleted.', 'success');
-    return result;
+    const result = await response.json();
+    setWaitingState(false, tableData);
+
+    if (response.status === 200) {
+      _notify(result.updated ? 'Table successfully updated.' : 'Empty table deleted.', 'success');
+      return result;
+    }
+
+    if (response.status === 400) _notify('One or more fields of table are not valid.');
+    if (response.status === 401) _notify('Please authorize.');
+    if (response.status === 404) _notify('Table not found.');
+    if (response.status === 500) _notify(result.error);
   }
-
-  if (response.status === 400) _notify('One or more fields of table are not valid.');
-  if (response.status === 401) _notify('Please authorize.');
-  if (response.status === 404) _notify('Table not found.');
-  if (response.status === 500) _notify(result.error);
 }
 
 export default updateTable;

--- a/public/js/services/update-table.js
+++ b/public/js/services/update-table.js
@@ -7,7 +7,7 @@ import getDefaultTimeoutDuration from '../utils/get-default-timeout-duration.js'
  * Update existing table.
  * @param {HTMLButtonElement} btn
  * @param {object} tableData
- * @param {number|boolean} [showResultDuration] - time in ms OR false (response returns)
+ * @param {number|boolean} [showResultDuration] - time in ms OR false (response is returned)
  */
 async function updateTable(btn, tableData, showResultDuration) {
   // exclude tableId and convert data to JSON

--- a/public/js/table/table-utils/save-delete/collect-table-data-and-save.js
+++ b/public/js/table/table-utils/save-delete/collect-table-data-and-save.js
@@ -6,6 +6,7 @@ import isEmptyString from '../../../utils/is-empty-string.js';
 import { shownTables, savedTablesHyphenIds } from '../../state-collectors/index.js';
 import { saveNewTable, updateTable } from '../../../services/index.js';
 import notify from '../notify.js';
+import getDefaultTimeoutDuration from '../../../utils/get-default-timeout-duration.js';
 
 /**
  * Collect table data and invoke saveNewTable or updateTable function.
@@ -25,7 +26,7 @@ async function collectTableDataAndSave(btn, { tableId }) {
     tbodyRows = collectRowsData(tableElem.children[1]);
 
   } catch (error) {
-    notify(tableId, error.message, 'error', 3000);
+    notify(tableId, error.message, 'error', getDefaultTimeoutDuration());
     return;
   }
 

--- a/public/js/utils/get-default-timeout-duration.js
+++ b/public/js/utils/get-default-timeout-duration.js
@@ -1,0 +1,7 @@
+/**
+ * Get default time for setTimeout.
+ * @returns {number} - ms
+ */
+const getDefaultTimeoutDuration = () => 3000;
+
+export default getDefaultTimeoutDuration;

--- a/public/js/utils/validate-positive-number.js
+++ b/public/js/utils/validate-positive-number.js
@@ -1,7 +1,8 @@
 /**
  * Return positive number or provided defaultValue, or false.
  * @param {number} val - any value
- * @param {number} defaultVal
+ * @param {number} [defaultVal]
+ * @returns {boolean|number} - false or number > 0
  */
 function validatePositiveNumber(val, defaultVal) {
   const valid = typeof val === 'number' && Number.isFinite(val) && val > 0 && val;


### PR DESCRIPTION
Turn off visualize logic (spinner, notifications) and get just a response by providing `showResultDuration` as false when calling a table service.